### PR TITLE
feat: add opbnb spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.18](https://github.com/alloy-rs/chains/releases/tag/v0.1.18) - 2024-05-14
+
+### Bug Fixes
+
+- Update Amoy testnet endpoints ([#63](https://github.com/alloy-rs/chains/issues/63))
+- Correct Arbiturm blocktime hint  ([#62](https://github.com/alloy-rs/chains/issues/62))
+- Correct Etherscan URLs for Blast Sepolia ([#60](https://github.com/alloy-rs/chains/issues/60))
+
 ## [0.1.17](https://github.com/alloy-rs/chains/releases/tag/v0.1.17) - 2024-04-23
 
 ### Bug Fixes
@@ -15,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [chain] Add method optimism_mainnet ([#58](https://github.com/alloy-rs/chains/issues/58))
 - Add degen chain ([#57](https://github.com/alloy-rs/chains/issues/57))
+
+### Miscellaneous Tasks
+
+- Release 0.1.17
 
 ## [0.1.16](https://github.com/alloy-rs/chains/releases/tag/v0.1.16) - 2024-04-10
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "alloy-chains"
 description = "Canonical type definitions for EIP-155 chains"
-version = "0.1.17"
+version = "0.1.18"
 edition = "2021"
 rust-version = "1.65"
 authors = ["Alloy Contributors"]

--- a/assets/chains.json
+++ b/assets/chains.json
@@ -788,8 +788,8 @@
       "supportsShanghai": false,
       "isTestnet": true,
       "nativeCurrencySymbol": null,
-      "etherscanApiUrl": "https://www.oklink.com/api/v5/explorer/AMOY_TESTNET/api",
-      "etherscanBaseUrl": "https://www.oklink.com/amoy",
+      "etherscanApiUrl": "https://api-amoy.polygonscan.com/api",
+      "etherscanBaseUrl": "https://amoy.polygonscan.com",
       "etherscanApiKeyName": "POLYGONSCAN_API_KEY"
     },
     "81457": {

--- a/assets/chains.json
+++ b/assets/chains.json
@@ -303,7 +303,7 @@
     "404": {
       "internalId": "Syndr",
       "name": "syndr",
-      "averageBlocktimeHint": 1300,
+      "averageBlocktimeHint": 260,
       "isLegacy": false,
       "supportsShanghai": true,
       "isTestnet": false,
@@ -627,7 +627,7 @@
     "42161": {
       "internalId": "Arbitrum",
       "name": "arbitrum",
-      "averageBlocktimeHint": 1300,
+      "averageBlocktimeHint": 260,
       "isLegacy": false,
       "supportsShanghai": true,
       "isTestnet": false,
@@ -639,7 +639,7 @@
     "42170": {
       "internalId": "ArbitrumNova",
       "name": "arbitrum-nova",
-      "averageBlocktimeHint": 1300,
+      "averageBlocktimeHint": 260,
       "isLegacy": false,
       "supportsShanghai": true,
       "isTestnet": false,
@@ -855,7 +855,7 @@
     "421611": {
       "internalId": "ArbitrumTestnet",
       "name": "arbitrum-testnet",
-      "averageBlocktimeHint": 1300,
+      "averageBlocktimeHint": 260,
       "isLegacy": true,
       "supportsShanghai": false,
       "isTestnet": true,
@@ -867,7 +867,7 @@
     "421613": {
       "internalId": "ArbitrumGoerli",
       "name": "arbitrum-goerli",
-      "averageBlocktimeHint": 1300,
+      "averageBlocktimeHint": 260,
       "isLegacy": false,
       "supportsShanghai": false,
       "isTestnet": true,
@@ -879,7 +879,7 @@
     "421614": {
       "internalId": "ArbitrumSepolia",
       "name": "arbitrum-sepolia",
-      "averageBlocktimeHint": 1300,
+      "averageBlocktimeHint": 260,
       "isLegacy": false,
       "supportsShanghai": true,
       "isTestnet": true,
@@ -891,7 +891,7 @@
     "444444": {
       "internalId": "SyndrSepolia",
       "name": "syndr-sepolia",
-      "averageBlocktimeHint": 1300,
+      "averageBlocktimeHint": 260,
       "isLegacy": false,
       "supportsShanghai": true,
       "isTestnet": true,

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -384,6 +384,18 @@ impl Chain {
         Self::from_named(NamedChain::Dev)
     }
 
+    /// Returns the bsc mainnet chain.
+    #[inline]
+    pub const fn bsc_mainnet() -> Self {
+        Self::from_named(NamedChain::BNBSmartChain)
+    }
+
+    /// Returns the bsc testnet chain.
+    #[inline]
+    pub const fn bsc_testnet() -> Self {
+        Self::from_named(NamedChain::BNBSmartChainTestnet)
+    }
+
     /// Returns the opbnb mainnet chain.
     #[inline]
     pub const fn opbnb_mainnet() -> Self {

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -384,6 +384,18 @@ impl Chain {
         Self::from_named(NamedChain::Dev)
     }
 
+    /// Returns the opbnb mainnet chain.
+    #[inline]
+    pub const fn opbnb_mainnet() -> Self {
+        Self::from_named(NamedChain::OpBNBMainnet)
+    }
+
+    /// Returns the opbnb testnet chain.
+    #[inline]
+    pub const fn opbnb_testnet() -> Self {
+        Self::from_named(NamedChain::OpBNBTestnet)
+    }
+
     /// Returns the kind of this chain.
     #[inline]
     pub const fn kind(&self) -> &ChainKind {
@@ -419,6 +431,8 @@ impl Chain {
                     | NamedChain::ZoraGoerli
                     | NamedChain::ZoraSepolia
                     | NamedChain::BlastSepolia
+                    | NamedChain::OpBNBMainnet
+                    | NamedChain::OpBNBTestnet
             )
         )
     }

--- a/src/named.rs
+++ b/src/named.rs
@@ -780,10 +780,9 @@ impl NamedChain {
             C::PolygonMumbai => {
                 ("https://api-testnet.polygonscan.com/api", "https://mumbai.polygonscan.com")
             }
-            C::PolygonAmoy => (
-                "https://www.oklink.com/api/v5/explorer/AMOY_TESTNET/api",
-                "https://www.oklink.com/amoy",
-            ),
+            C::PolygonAmoy => {
+                ("https://api-amoy.polygonscan.com/api", "https://amoy.polygonscan.com")
+            }
 
             C::PolygonZkEvm => {
                 ("https://api-zkevm.polygonscan.com/api", "https://zkevm.polygonscan.com")

--- a/src/named.rs
+++ b/src/named.rs
@@ -377,7 +377,7 @@ impl NamedChain {
             | C::ArbitrumSepolia
             | C::Syndr
             | C::SyndrSepolia
-            | C::ArbitrumNova => 1_300,
+            | C::ArbitrumNova => 260,
 
             C::Optimism
             | C::OptimismGoerli

--- a/src/named.rs
+++ b/src/named.rs
@@ -235,6 +235,11 @@ pub enum NamedChain {
     EtherlinkTestnet = 128123,
 
     Degen = 666666666,
+
+    #[cfg_attr(feature = "serde", serde(alias = "opbnb-mainnet"))]
+    OpBNBMainnet = 204,
+    #[cfg_attr(feature = "serde", serde(alias = "opbnb-testnet"))]
+    OpBNBTestnet = 5611,
 }
 
 // This must be implemented manually so we avoid a conflict with `TryFromPrimitive` where it treats
@@ -460,6 +465,9 @@ impl NamedChain {
             | C::Mantle
             | C::MantleTestnet
             | C::KakarotSepolia => return None,
+
+            C::OpBNBMainnet
+            | C::OpBNBTestnet => 1_000,
         }))
     }
 
@@ -545,7 +553,9 @@ impl NamedChain {
             | C::PgnSepolia
             | C::KakarotSepolia
             | C::EtherlinkTestnet
-            | C::Degen => false,
+            | C::Degen
+            | C::OpBNBMainnet
+            | C::OpBNBTestnet => false,
 
             // Unknown / not applicable, default to false for backwards compatibility.
             C::Dev
@@ -606,7 +616,9 @@ impl NamedChain {
             | C::SyndrSepolia
             | C::EtherlinkTestnet
             | C::Scroll
-            | C::ScrollSepolia => true,
+            | C::ScrollSepolia
+            | C::OpBNBMainnet
+            | C::OpBNBTestnet => true,
             _ => false,
         }
     }
@@ -667,7 +679,8 @@ impl NamedChain {
             | C::ModeSepolia
             | C::PgnSepolia
             | C::KakarotSepolia
-            | C::EtherlinkTestnet => true,
+            | C::EtherlinkTestnet
+            | C::OpBNBTestnet => true,
 
             // Dev chains.
             C::Dev | C::AnvilHardhat => true,
@@ -713,7 +726,8 @@ impl NamedChain {
             | C::Mode
             | C::Viction
             | C::Elastos
-            | C::Degen => false,
+            | C::Degen
+            | C::OpBNBMainnet => false,
         }
     }
 
@@ -733,7 +747,10 @@ impl NamedChain {
             | C::Scroll
             | C::ScrollSepolia => "ETH",
 
-            C::BinanceSmartChain | C::BinanceSmartChainTestnet => "BNB",
+            C::BinanceSmartChain
+            | C::BinanceSmartChainTestnet
+            | C::OpBNBMainnet
+            | C::OpBNBTestnet => "BNB",
 
             C::EtherlinkTestnet => "XTZ",
 
@@ -822,6 +839,11 @@ impl NamedChain {
             C::BinanceSmartChain => ("https://api.bscscan.com/api", "https://bscscan.com"),
             C::BinanceSmartChainTestnet => {
                 ("https://api-testnet.bscscan.com/api", "https://testnet.bscscan.com")
+            }
+
+            C::OpBNBMainnet => ("https://opbnb.bscscan.com/api", "https://opbnb.bscscan.com/"),
+            C::OpBNBTestnet => {
+                ("https://opbnb-testnet.bscscan.com/api", "https://opbnb-testnet.bscscan.com/")
             }
 
             C::Arbitrum => ("https://api.arbiscan.io/api", "https://arbiscan.io"),
@@ -1019,6 +1041,8 @@ impl NamedChain {
             | C::OptimismSepolia
             | C::BinanceSmartChain
             | C::BinanceSmartChainTestnet
+            | C::OpBNBMainnet
+            | C::OpBNBTestnet
             | C::Arbitrum
             | C::ArbitrumTestnet
             | C::ArbitrumGoerli

--- a/src/named.rs
+++ b/src/named.rs
@@ -73,15 +73,15 @@ pub enum NamedChain {
 
     Rsk = 30,
 
-    #[strum(to_string = "bsc", serialize = "binance-smart-chain")]
-    #[cfg_attr(feature = "serde", serde(alias = "bsc", alias = "binance-smart-chain"))]
-    BinanceSmartChain = 56,
-    #[strum(to_string = "bsc-testnet", serialize = "binance-smart-chain-testnet")]
+    #[strum(to_string = "bsc", serialize = "bnb-smart-chain")]
+    #[cfg_attr(feature = "serde", serde(alias = "bsc", alias = "bnb-smart-chain"))]
+    BNBSmartChain = 56,
+    #[strum(to_string = "bsc-testnet", serialize = "bnb-smart-chain-testnet")]
     #[cfg_attr(
         feature = "serde",
-        serde(alias = "bsc_testnet", alias = "bsc-testnet", alias = "binance-smart-chain-testnet")
+        serde(alias = "bsc_testnet", alias = "bsc-testnet", alias = "bnb-smart-chain-testnet")
     )]
-    BinanceSmartChainTestnet = 97,
+    BNBSmartChainTestnet = 97,
 
     Poa = 99,
     Sokol = 77,
@@ -408,7 +408,7 @@ impl NamedChain {
 
             C::Moonbeam | C::Moonriver => 12_500,
 
-            C::BinanceSmartChain | C::BinanceSmartChainTestnet => 3_000,
+            C::BNBSmartChain | C::BNBSmartChainTestnet => 3_000,
 
             C::Avalanche | C::AvalancheFuji => 2_000,
 
@@ -489,8 +489,8 @@ impl NamedChain {
             C::OptimismKovan
             | C::Fantom
             | C::FantomTestnet
-            | C::BinanceSmartChain
-            | C::BinanceSmartChainTestnet
+            | C::BNBSmartChain
+            | C::BNBSmartChainTestnet
             | C::ArbitrumTestnet
             | C::Rsk
             | C::Oasis
@@ -653,7 +653,7 @@ impl NamedChain {
             | C::BaseGoerli
             | C::BaseSepolia
             | C::BlastSepolia
-            | C::BinanceSmartChainTestnet
+            | C::BNBSmartChainTestnet
             | C::CantoTestnet
             | C::CronosTestnet
             | C::CeloAlfajores
@@ -694,7 +694,7 @@ impl NamedChain {
             | C::Syndr
             | C::Cronos
             | C::Rsk
-            | C::BinanceSmartChain
+            | C::BNBSmartChain
             | C::Poa
             | C::Sokol
             | C::Scroll
@@ -747,8 +747,8 @@ impl NamedChain {
             | C::Scroll
             | C::ScrollSepolia => "ETH",
 
-            C::BinanceSmartChain
-            | C::BinanceSmartChainTestnet
+            C::BNBSmartChain
+            | C::BNBSmartChainTestnet
             | C::OpBNBMainnet
             | C::OpBNBTestnet => "BNB",
 
@@ -836,8 +836,8 @@ impl NamedChain {
                 ("https://api-testnet.ftmscan.com/api", "https://testnet.ftmscan.com")
             }
 
-            C::BinanceSmartChain => ("https://api.bscscan.com/api", "https://bscscan.com"),
-            C::BinanceSmartChainTestnet => {
+            C::BNBSmartChain => ("https://api.bscscan.com/api", "https://bscscan.com"),
+            C::BNBSmartChainTestnet => {
                 ("https://api-testnet.bscscan.com/api", "https://testnet.bscscan.com")
             }
 
@@ -1039,8 +1039,8 @@ impl NamedChain {
             | C::OptimismGoerli
             | C::OptimismKovan
             | C::OptimismSepolia
-            | C::BinanceSmartChain
-            | C::BinanceSmartChainTestnet
+            | C::BNBSmartChain
+            | C::BNBSmartChainTestnet
             | C::OpBNBMainnet
             | C::OpBNBTestnet
             | C::Arbitrum
@@ -1215,8 +1215,8 @@ mod tests {
         // kebab-case
         const ALIASES: &[(NamedChain, &[&str])] = &[
             (Mainnet, &["ethlive"]),
-            (BinanceSmartChain, &["bsc", "binance-smart-chain"]),
-            (BinanceSmartChainTestnet, &["bsc-testnet", "binance-smart-chain-testnet"]),
+            (BNBSmartChain, &["bsc", "bnb-smart-chain"]),
+            (BNBSmartChainTestnet, &["bsc-testnet", "bnb-smart-chain-chapel"]),
             (Gnosis, &["gnosis", "gnosis-chain"]),
             (PolygonMumbai, &["mumbai"]),
             (PolygonZkEvm, &["zkevm", "polygon-zkevm"]),


### PR DESCRIPTION
## Description

introduce the chain spec of opBNB mainnet/testnet.

This aims to make reth support the opBNB network.

## Related
https://github.com/bnb-chain/reth/pull/1